### PR TITLE
feat: add task pomodoro create serializer to be used to task post method

### DIFF
--- a/pomodoro/tasks/serializers.py
+++ b/pomodoro/tasks/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from .models import Task
+
+
+class TaskPomodoroCreateSerializer(serializers.ModelSerializer):
+    """Task Create model Serializer"""
+
+    pomodoro_count = serializers.IntegerField(max_value=42, min_value=1)
+
+    class Meta:
+        model = Task
+        fields = ["name", "pomodoro_count"]


### PR DESCRIPTION
task POST method에 사용할, serializer 생성.  
task를 생성할 때 pomodoro를 적어도 1개 생성하므로 serializer에 pomodoro의 개수를 지정할 수 있도록  
모델에 정의한 field이외의 extra field를 serializer에 정의.