### PR TITLE
fix: modify serializer code

### DIFF
--- a/pomodoro/projects/views.py
+++ b/pomodoro/projects/views.py
@@ -35,7 +35,7 @@ class ProjectListView(APIView):
 
         serializer.save(user=request.user)
 
-        return Response(serializer.validated_data, status=status.HTTP_201_CREATED)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 # TODO: projects List View를 생성한 뒤 기능 구현 할 것. 231121부터 할 것.

--- a/pomodoro/projects/views.py
+++ b/pomodoro/projects/views.py
@@ -57,17 +57,16 @@ class TaskListView(APIView):
         # validate를 통과하지 못할 시, 400 bad request를 응답한다.
         # validate를 통과하지 못할 시의 커스텀 response를 정의하지 않는다면
         # 옵션 설정 하나로 변하게 코드를 작성할 수 있다.
-        if serializer.is_valid(raise_exception=True):
-            validated_data = serializer.validated_data
-            # data는 name과 pomodoro_count다. pomodoro_count는 Task에 필요없는 데이터인데
-            # 이 경우에는 어떻게 처리될까?
-            # TypeError unexpected keyword arguments 'pomodoro_count'가 나온다.
-            # 그러므로 pop을 해줘서 pomodoro_count는 별도로 취득한다.
-            pomodoro_count = serializer.validated_data.pop("pomodoro_count")
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
+        # data는 name과 pomodoro_count다. pomodoro_count는 Task에 필요없는 데이터인데
+        # 이 경우에는 어떻게 처리될까?
+        # TypeError unexpected keyword arguments 'pomodoro_count'가 나온다.
+        # 그러므로 pop을 해줘서 pomodoro_count는 별도로 취득한다.
+        pomodoro_count = serializer.validated_data.pop("pomodoro_count")
+        with transaction.atomic():
+            # TODO: projects에 정의되어잇는 ManyToMany를 여기에 정의해서 처리하도록 한다.
+            serializer.save()
+        # TODO: 생성된 Task과 Pomodoro의 데이터를 response에 받을 수 있도록 한다.
 
-            with transaction.atomic():
-                # TODO: projects에 정의되어잇는 ManyToMany를 여기에 정의해서 처리하도록 한다.
-                serializer.save()
-
-            # TODO: 생성된 Task과 Pomodoro의 데이터를 response에 받을 수 있도록 한다.
-            return Response(status=status.HTTP_201_CREATED)
+        return Response(status=status.HTTP_201_CREATED)


### PR DESCRIPTION
serializer활용이 알맞지 않았으므로 수정
- validate 후에 반환하는 data는 `serializer.data`여야 한다. `serializer.save()`후에 데이터베이스에 저장된 데이터가 담기기 때문이다.  
 ex. model의 id
- serializer에 `raise_exception`옵션을 사용하고 있으므로 if문은 필요없다.