### PR TITLE
fix: modify task list view post method to process creating Task and Pomodoros

### DIFF
--- a/pomodoro/config/settings.py
+++ b/pomodoro/config/settings.py
@@ -164,6 +164,7 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFALUT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
+    "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",
 }
 
 SIMPLE_JWT = {

--- a/pomodoro/pomodoros/models.py
+++ b/pomodoro/pomodoros/models.py
@@ -9,9 +9,12 @@ class Pomodoro(core_models.TimeStampedModel):
     class Meta:
         db_table = "pomodoros"
 
-    pomodoro_length = models.IntegerField(verbose_name="pomodoro time length")
-    break_length = models.IntegerField(verbose_name="break time length")
-    tasks = models.ForeignKey(
+    pomodoro_length = models.IntegerField(
+        verbose_name="pomodoro time length", default=25
+    )
+    break_length = models.IntegerField(verbose_name="break time length", default=5)
+    # TODO: squash 해보기
+    task = models.ForeignKey(
         "tasks.Task",
         verbose_name="related task",
         related_name="pomodoros",

--- a/pomodoro/projects/views.py
+++ b/pomodoro/projects/views.py
@@ -1,4 +1,5 @@
 from rest_framework import status
+from rest_framework.exceptions import NotFound
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -58,15 +59,18 @@ class TaskListView(APIView):
         # validate를 통과하지 못할 시의 커스텀 response를 정의하지 않는다면
         # 옵션 설정 하나로 변하게 코드를 작성할 수 있다.
         serializer.is_valid(raise_exception=True)
-        validated_data = serializer.validated_data
         # data는 name과 pomodoro_count다. pomodoro_count는 Task에 필요없는 데이터인데
         # 이 경우에는 어떻게 처리될까?
         # TypeError unexpected keyword arguments 'pomodoro_count'가 나온다.
         # 그러므로 pop을 해줘서 pomodoro_count는 별도로 취득한다.
-        pomodoro_count = serializer.validated_data.pop("pomodoro_count")
         with transaction.atomic():
             # TODO: projects에 정의되어잇는 ManyToMany를 여기에 정의해서 처리하도록 한다.
-            serializer.save()
-        # TODO: 생성된 Task과 Pomodoro의 데이터를 response에 받을 수 있도록 한다.
+            try:
+                project = Project.objects.get(id=pk)
+            except Project.DoesNotExist:
+                raise NotFound(detail="Project Not Found")
+            task = serializer.save()
+            project.tasks.add(task)
 
-        return Response(status=status.HTTP_201_CREATED)
+        # TODO: 생성된 Task과 Pomodoro의 데이터를 response에 받을 수 있도록
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/pomodoro/tasks/serializers.py
+++ b/pomodoro/tasks/serializers.py
@@ -1,3 +1,4 @@
+from pomodoros.models import Pomodoro
 from rest_framework import serializers
 
 from .models import Task
@@ -7,7 +8,18 @@ class TaskPomodoroCreateSerializer(serializers.ModelSerializer):
     """Task Create model Serializer"""
 
     pomodoro_count = serializers.IntegerField(max_value=42, min_value=1)
+    # TODO: Pomodoro의 데이터도 같이 response할 수 있도록 필드 추가하기 231124
+    # https://www.django-rest-framework.org/api-guide/relations/
+    # pomodoros = serializers.
 
     class Meta:
         model = Task
-        fields = ["name", "pomodoro_count"]
+        fields = ["name", "pomodoro_count", "pomodoros"]
+
+    def create(self, validated_data):
+        pomodoro_count = validated_data.pop("pomodoro_count")
+        task = Task.objects.create(**validated_data)
+        pomodoros = [Pomodoro(task=task) for _ in range(pomodoro_count)]
+        Pomodoro.objects.bulk_create(pomodoros)
+
+        return task


### PR DESCRIPTION
- `Task`를 생성할 때 `Pomodoro`도 같이 생성하도록 로직 변경
- 231125에 생성 뒤, `Pomodoro`의 데이터도 같이 response하도록 serializer 수정하기